### PR TITLE
Initial page setup for Legal-Notices on Cyclr Docs site. sd-1894

### DIFF
--- a/_data/sidebars/cyclr_sidebar.yml
+++ b/_data/sidebars/cyclr_sidebar.yml
@@ -106,6 +106,10 @@ entries:
           - title: Performance Tips
             url: /performance-tips
             output: web, pdf
+            
+          - title: Legal Notices
+            url: /legal-notices
+            output: web, pdf            
 
       - title: Embedding Cyclr
         output: web, pdf

--- a/pages/managing-cyclr/legal-notices.md
+++ b/pages/managing-cyclr/legal-notices.md
@@ -9,9 +9,8 @@ tags: [managing-cyclr]
 ### Terms and Conditions
 Cyclr's [Terms and Conditions](https://cyclr.com/terms-and-conditions)
 
-### Trademarks
-Wording TBC
-
+### The Cyclr Application Stack
+The Cyclr [Application Stack](https://cyclr.com/cyclr/application-stack)
 
 ### Third Party Notices
 The software provided by the Cyclr service may contain software available under open source or free software licenses ("Open Source Software") and/or commercial software licensed to Cyclr by parties ("Commercial Software").  The Cyclr Terms of Use do not alter any rights or obligations you may have under those Open Source Software licenses.  Additional information about Open Source and Commercial Software, including required acknowledgements, license terms and notices, can be found below.  
@@ -40,8 +39,8 @@ The software provided by the Cyclr service may contain software available under 
 | Castle.Core | [http://www.apache.org/licenses/LICENSE-2.0.html](http://www.apache.org/licenses/LICENSE-2.0.html) |
 | Chart.js | [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT) |
 | CommandLineParser | [https://github.com/commandlineparser/commandline/blob/master/License.md](https://github.com/commandlineparser/commandline/blob/master/License.md) |
-| Common.Logging |
-| Common.Logging.Core |
+| Common.Logging | [http://www.apache.org/licenses/LICENSE-2.0.html](http://www.apache.org/licenses/LICENSE-2.0.html) |
+| Common.Logging.Core | [http://www.apache.org/licenses/LICENSE-2.0.html](http://www.apache.org/licenses/LICENSE-2.0.html) |
 | CsvHelper | [https://licenses.nuget.org/MS-PL%20OR%20Apache-2.0](https://licenses.nuget.org/MS-PL%20OR%20Apache-2.0) |
 | DiffPlex | [https://github.com/mmanela/diffplex/blob/master/License.txt](https://github.com/mmanela/diffplex/blob/master/License.txt) |
 | DnsClient | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
@@ -59,9 +58,9 @@ The software provided by the Cyclr service may contain software available under 
 | jQuery.Cookie | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
 | jQuery.Steps | [https://github.com/rstaib/jquery-steps/blob/master/LICENSE.txt](https://github.com/rstaib/jquery-steps/blob/master/LICENSE.txt) |
 | jQuery.UI.Combined | [http://jquery.org/license](http://jquery.org/license) |
-| jQuery.Validation |
-| jQuery-UI.Touch-Punch |
-| JUnitTestLogger |
+| jQuery.Validation | [https://github.com/jquery-validation/jquery-validation/blob/master/LICENSE.md](https://github.com/jquery-validation/jquery-validation/blob/master/LICENSE.md) |
+| jQuery-UI.Touch-Punch | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| JUnitTestLogger | [https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE](https://github.com/syncromatics/JUnitTestLogger/blob/master/LICENSE) |
 | knockoutjs | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
 | ladda-bootstrap | [https://github.com/hakimel/Ladda/blob/master/LICENSE](https://github.com/hakimel/Ladda/blob/master/LICENSE) |
 | LibGit2Sharp | [https://github.com/libgit2/libgit2sharp/raw/9a87d4c3d8/LICENSE.md](https://github.com/libgit2/libgit2sharp/raw/9a87d4c3d8/LICENSE.md) |
@@ -161,10 +160,10 @@ The software provided by the Cyclr service may contain software available under 
 | Mono.Cecil | [http://opensource.org/licenses/mit-license.php](http://opensource.org/licenses/mit-license.php) |
 | Moq | [https://raw.githubusercontent.com/moq/moq4/master/License.txt](https://raw.githubusercontent.com/moq/moq4/master/License.txt) |
 | Mvc3Futures | [http://www.microsoft.com/web/webpi/eula/aspnetcomponent_enu.htm](http://www.microsoft.com/web/webpi/eula/aspnetcomponent_enu.htm) |
-| MvcSiteMapProvider.MVC5 |
-| MvcSiteMapProvider.MVC5.Core |
-| MvcSiteMapProvider.MVC5.DI.Autofac.Modules |
-| MvcSiteMapProvider.Web |
+| MvcSiteMapProvider.MVC5 | [https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md](https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md) |
+| MvcSiteMapProvider.MVC5.Core | [https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md](https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md) |
+| MvcSiteMapProvider.MVC5.DI.Autofac.Modules | [https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md](https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md) |
+| MvcSiteMapProvider.Web | [https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md](https://github.com/maartenba/MvcSiteMapProvider/blob/master/LICENSE.md) |
 | MySqlConnector | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
 | NEST | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
 | NETStandard.Library | [https://github.com/dotnet/standard/blob/master/LICENSE.TXT](https://github.com/dotnet/standard/blob/master/LICENSE.TXT) |
@@ -174,7 +173,7 @@ The software provided by the Cyclr service may contain software available under 
 | NLog | [https://github.com/NLog/NLog/blob/master/LICENSE.txt](https://github.com/NLog/NLog/blob/master/LICENSE.txt) |
 | NLog.Config | [https://github.com/NLog/NLog/blob/master/LICENSE.txt](https://github.com/NLog/NLog/blob/master/LICENSE.txt) |
 | NodaTime | [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0) |
-| Npgsql |
+| Npgsql | [https://github.com/npgsql/npgsql/blob/main/LICENSE](https://github.com/npgsql/npgsql/blob/main/LICENSE) |
 | nunit | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
 | NUnit | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
 | NUnit3TestAdapter | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
@@ -187,7 +186,7 @@ The software provided by the Cyclr service may contain software available under 
 | PagedList.Mvc | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
 | Pipelines.Sockets.Unofficial | [https://raw.githubusercontent.com/mgravell/Pipelines.Sockets.Unofficial/master/LICENSE](https://raw.githubusercontent.com/mgravell/Pipelines.Sockets.Unofficial/master/LICENSE) |
 | Pomelo.EntityFrameworkCore.MySql | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
-| Pomelo.JsonObject |
+| Pomelo.JsonObject | [https://github.com/PomeloFoundation/Pomelo.JsonObject/blob/master/LICENSE](https://github.com/PomeloFoundation/Pomelo.JsonObject/blob/master/LICENSE) |
 | Portable.BouncyCastle | [https://www.bouncycastle.org/csharp/licence.html](https://www.bouncycastle.org/csharp/licence.html) |
 | Proc | [https://github.com/nullean/proc/blob/master/license.txt](https://github.com/nullean/proc/blob/master/license.txt) |
 | Quartz | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
@@ -205,7 +204,7 @@ The software provided by the Cyclr service may contain software available under 
 | Sammy.js | [https://github.com/quirkey/sammy/blob/master/LICENSE](https://github.com/quirkey/sammy/blob/master/LICENSE) |
 | SauceControl.InheritDoc | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
 | SharpCompress | [https://github.com/adamhathcock/sharpcompress/blob/master/LICENSE.txt](https://github.com/adamhathcock/sharpcompress/blob/master/LICENSE.txt) |
-| Spin.js |
+| Spin.js | [https://github.com/fgnass/spin.js/blob/master/LICENSE.md](https://github.com/fgnass/spin.js/blob/master/LICENSE.md) |
 | SSH.NET | [https://github.com/sshnet/SSH.NET/blob/master/LICENSE](https://github.com/sshnet/SSH.NET/blob/master/LICENSE) |
 | StackExchange.Redis | [https://raw.github.com/StackExchange/StackExchange.Redis/master/LICENSE](https://raw.github.com/StackExchange/StackExchange.Redis/master/LICENSE) |
 | SweetAlert.Base | [https://github.com/t4t5/sweetalert/blob/master/LICENSE](https://github.com/t4t5/sweetalert/blob/master/LICENSE) |
@@ -264,7 +263,7 @@ The software provided by the Cyclr service may contain software available under 
 | System.Threading.ThreadPool | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
 | System.ValueTuple | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
 | System.Xml.ReaderWriter | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
-| TimeZoneConverter |
+| TimeZoneConverter | [https://github.com/mattjohnsonpint/TimeZoneConverter/blob/main/LICENSE.txt](https://github.com/mattjohnsonpint/TimeZoneConverter/blob/main/LICENSE.txt) |
 | toastr | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
 | Twitter.Bootstrap.Less | [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT) |
 | WebActivatorEx | [http://opensource.org/licenses/Apache-2.0](http://opensource.org/licenses/Apache-2.0) |

--- a/pages/managing-cyclr/legal-notices.md
+++ b/pages/managing-cyclr/legal-notices.md
@@ -1,0 +1,273 @@
+---
+title: Legal Notices
+sidebar: cyclr_sidebar
+permalink: legal-notices
+tags: [managing-cyclr]
+
+---
+
+### Terms and Conditions
+Cyclr's [Terms and Conditions](https://cyclr.com/terms-and-conditions)
+
+### Trademarks
+Wording TBC
+
+
+### Third Party Notices
+The software provided by the Cyclr service may contain software available under open source or free software licenses ("Open Source Software") and/or commercial software licensed to Cyclr by parties ("Commercial Software").  The Cyclr Terms of Use do not alter any rights or obligations you may have under those Open Source Software licenses.  Additional information about Open Source and Commercial Software, including required acknowledgements, license terms and notices, can be found below.  
+
+| Third Party Package | License URL |
+| --- | --- |
+| Antlr | [http://www.antlr3.org/license.html](http://www.antlr3.org/license.html) |
+| Autofac | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Autofac.Extensions.DependencyInjection | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Autofac.Mvc5 | [https://opensource.org/licenses/mit-license.php](https://opensource.org/licenses/mit-license.php) |
+| Autofac.Mvc5.Owin | [https://opensource.org/licenses/mit-license.php](https://opensource.org/licenses/mit-license.php) |
+| Autofac.Owin | [https://opensource.org/licenses/mit-license.php](https://opensource.org/licenses/mit-license.php) |
+| Autofac.SignalR | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
+| Autofac.WebApi2 | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Autofac.WebApi2.Owin | [https://opensource.org/licenses/mit-license.php](https://opensource.org/licenses/mit-license.php) |
+| AutoMapper | [https://github.com/AutoMapper/AutoMapper/blob/master/LICENSE.txt](https://github.com/AutoMapper/AutoMapper/blob/master/LICENSE.txt) |
+| Automatonymous | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| autosize | [http://opensource.org/licenses/mit-license.php](http://opensource.org/licenses/mit-license.php) |
+| AWS.Logger.Core | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| AWS.Logger.NLog | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| AWSSDK.CloudWatch | [http://aws.amazon.com/apache2.0/](http://aws.amazon.com/apache2.0/) |
+| AWSSDK.CloudWatchLogs | [http://aws.amazon.com/apache2.0/](http://aws.amazon.com/apache2.0/) |
+| AWSSDK.Core | [http://aws.amazon.com/apache2.0/](http://aws.amazon.com/apache2.0/) |
+| Base32 | [https://s3.amazonaws.com/OtpSharp/LICENSE.txt](https://s3.amazonaws.com/OtpSharp/LICENSE.txt) |
+| bootstrap.less | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| Castle.Core | [http://www.apache.org/licenses/LICENSE-2.0.html](http://www.apache.org/licenses/LICENSE-2.0.html) |
+| Chart.js | [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT) |
+| CommandLineParser | [https://github.com/commandlineparser/commandline/blob/master/License.md](https://github.com/commandlineparser/commandline/blob/master/License.md) |
+| Common.Logging |
+| Common.Logging.Core |
+| CsvHelper | [https://licenses.nuget.org/MS-PL%20OR%20Apache-2.0](https://licenses.nuget.org/MS-PL%20OR%20Apache-2.0) |
+| DiffPlex | [https://github.com/mmanela/diffplex/blob/master/License.txt](https://github.com/mmanela/diffplex/blob/master/License.txt) |
+| DnsClient | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| dotless.Core | [https://github.com/dotless/dotless/blob/master/license.txt](https://github.com/dotless/dotless/blob/master/license.txt) |
+| Elastic.Elasticsearch.Ephemeral | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Elasticsearch.Net | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Esprima | [https://raw.githubusercontent.com/sebastienros/esprima-dotnet/master/LICENSE.txt](https://raw.githubusercontent.com/sebastienros/esprima-dotnet/master/LICENSE.txt) |
+| Facebook | [https://raw.github.com/facebook-csharp-sdk/facebook-csharp-sdk/master/LICENSE.txt](https://raw.github.com/facebook-csharp-sdk/facebook-csharp-sdk/master/LICENSE.txt) |
+| FluentFTP | [https://github.com/robinrodricks/FluentFTP/blob/master/LICENSE.TXT](https://github.com/robinrodricks/FluentFTP/blob/master/LICENSE.TXT) |
+| FontAwesome | [http://fontawesome.io/license/](http://fontawesome.io/license/) |
+| GreenPipes | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| IPNetwork2 | [https://github.com/lduchosal/ipnetwork/blob/master/LICENSE](https://github.com/lduchosal/ipnetwork/blob/master/LICENSE) |
+| JetBrains.Annotations | [https://raw.githubusercontent.com/JetBrains/ExternalAnnotations/master/LICENSE.md](https://raw.githubusercontent.com/JetBrains/ExternalAnnotations/master/LICENSE.md) |
+| jQuery | [http://jquery.org/license](http://jquery.org/license) |
+| jQuery.Cookie | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
+| jQuery.Steps | [https://github.com/rstaib/jquery-steps/blob/master/LICENSE.txt](https://github.com/rstaib/jquery-steps/blob/master/LICENSE.txt) |
+| jQuery.UI.Combined | [http://jquery.org/license](http://jquery.org/license) |
+| jQuery.Validation |
+| jQuery-UI.Touch-Punch |
+| JUnitTestLogger |
+| knockoutjs | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
+| ladda-bootstrap | [https://github.com/hakimel/Ladda/blob/master/LICENSE](https://github.com/hakimel/Ladda/blob/master/LICENSE) |
+| LibGit2Sharp | [https://github.com/libgit2/libgit2sharp/raw/9a87d4c3d8/LICENSE.md](https://github.com/libgit2/libgit2sharp/raw/9a87d4c3d8/LICENSE.md) |
+| LibGit2Sharp.NativeBinaries | [https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING](https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING) |
+| Magick.NET-Q16-AnyCPU | [https://github.com/dlemstra/Magick.NET/blob/master/License.txt](https://github.com/dlemstra/Magick.NET/blob/master/License.txt) |
+| MailKit | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| MassTransit | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| MassTransit.Autofac | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| MassTransit.RabbitMQ | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.ApplicationInsights | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.ApplicationInsights.NLogTarget | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.AspNet.Cors | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.Identity.Core | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.Identity.Owin | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.Mvc | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.Razor | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.SessionState.SessionStateModule | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.SignalR | [https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt](https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt) |
+| Microsoft.AspNet.SignalR.Core | [https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt](https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt) |
+| Microsoft.AspNet.SignalR.JS | [https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt](https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt) |
+| Microsoft.AspNet.SignalR.SystemWeb | [https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt](https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt) |
+| Microsoft.AspNet.Web.Optimization | [http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm](http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm) |
+| Microsoft.AspNet.WebApi | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebApi.Client | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebApi.Core | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebApi.Cors | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebApi.Owin | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebApi.WebHost | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebHelpers | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebPages | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebPages.Data | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNet.WebPages.WebData | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.AspNetCore.Http.Abstractions | [https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt](https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt) |
+| Microsoft.AspNetCore.Http.Extensions | [https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt](https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt) |
+| Microsoft.AspNetCore.Http.Features | [https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt](https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt) |
+| Microsoft.Bcl.AsyncInterfaces | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.Bcl.HashCode | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.CodeAnalysis.FxCopAnalyzers | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.CSharp | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.Diagnostics.Tracing.EventSource.Redist | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| Microsoft.EntityFrameworkCore | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.EntityFrameworkCore.Abstractions | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.EntityFrameworkCore.Analyzers | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.EntityFrameworkCore.Design | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.EntityFrameworkCore.InMemory | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.EntityFrameworkCore.Proxies | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.EntityFrameworkCore.Relational | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.EntityFrameworkCore.Tools | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Caching.Abstractions | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Caching.Memory | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Configuration | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Configuration.Abstractions | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Configuration.Binder | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Configuration.Json | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.Extensions.DependencyInjection | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.DependencyInjection.Abstractions | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.FileProviders.Abstractions | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Hosting | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.Extensions.Hosting.Abstractions | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.Extensions.Http | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Microsoft.Extensions.Logging | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Logging.Abstractions | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Options | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Extensions.Primitives | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.IdentityModel.JsonWebTokens | [https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt) |
+| Microsoft.IdentityModel.Logging | [https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt) |
+| Microsoft.IdentityModel.Protocol.Extensions | [https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt) |
+| Microsoft.IdentityModel.Protocols | [https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt) |
+| Microsoft.IdentityModel.Protocols.OpenIdConnect | [https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt) |
+| Microsoft.IdentityModel.Tokens | [https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt) |
+| Microsoft.jQuery.Unobtrusive.Ajax | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.jQuery.Unobtrusive.Validation | [http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm) |
+| Microsoft.Net.Http.Headers | [https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt](https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt) |
+| Microsoft.NET.Test.Sdk | [http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm](http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm) |
+| Microsoft.NETCore.App | [https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT](https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT) |
+| Microsoft.Owin | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Cors | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Host.SystemWeb | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Security | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Security.Cookies | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Security.Facebook | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Security.Google | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Security.OAuth | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Security.OpenIdConnect | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Owin.Security.Twitter | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Microsoft.Web.Infrastructure | [http://go.microsoft.com/fwlink/?LinkID=214339](http://go.microsoft.com/fwlink/?LinkID=214339) |
+| Microsoft.Web.RedisSessionStateProvider | [https://webpifeed.blob.core.windows.net/webpifeed/eula/net_library_eula_enu.htm](https://webpifeed.blob.core.windows.net/webpifeed/eula/net_library_eula_enu.htm) |
+| MimeKit | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| MimeMapping | [https://github.com/zone117x/MimeMapping/blob/master/LICENSE.md](https://github.com/zone117x/MimeMapping/blob/master/LICENSE.md) |
+| Modernizr | [http://www.modernizr.com/license/](http://www.modernizr.com/license/) |
+| Moment.js | [https://raw.github.com/timrwood/moment/master/LICENSE](https://raw.github.com/timrwood/moment/master/LICENSE) |
+| Moment.Timezone.js | [https://raw.githubusercontent.com/moment/moment-timezone/develop/LICENSE](https://raw.githubusercontent.com/moment/moment-timezone/develop/LICENSE) |
+| MongoDB.Bson | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| MongoDB.Driver | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| MongoDB.Driver.Core | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| MongoDB.Libmongocrypt | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| Mono.Cecil | [http://opensource.org/licenses/mit-license.php](http://opensource.org/licenses/mit-license.php) |
+| Moq | [https://raw.githubusercontent.com/moq/moq4/master/License.txt](https://raw.githubusercontent.com/moq/moq4/master/License.txt) |
+| Mvc3Futures | [http://www.microsoft.com/web/webpi/eula/aspnetcomponent_enu.htm](http://www.microsoft.com/web/webpi/eula/aspnetcomponent_enu.htm) |
+| MvcSiteMapProvider.MVC5 |
+| MvcSiteMapProvider.MVC5.Core |
+| MvcSiteMapProvider.MVC5.DI.Autofac.Modules |
+| MvcSiteMapProvider.Web |
+| MySqlConnector | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| NEST | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| NETStandard.Library | [https://github.com/dotnet/standard/blob/master/LICENSE.TXT](https://github.com/dotnet/standard/blob/master/LICENSE.TXT) |
+| NewId | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Newtonsoft.Json | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Newtonsoft.Json.Bson | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| NLog | [https://github.com/NLog/NLog/blob/master/LICENSE.txt](https://github.com/NLog/NLog/blob/master/LICENSE.txt) |
+| NLog.Config | [https://github.com/NLog/NLog/blob/master/LICENSE.txt](https://github.com/NLog/NLog/blob/master/LICENSE.txt) |
+| NodaTime | [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0) |
+| Npgsql |
+| nunit | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| NUnit | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| NUnit3TestAdapter | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| Octokit | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| OctoPack | [https://github.com/OctopusDeploy/OctoPack/blob/master/LICENSE.txt](https://github.com/OctopusDeploy/OctoPack/blob/master/LICENSE.txt) |
+| OtpSharp | [https://s3.amazonaws.com/OtpSharp/LICENSE.txt](https://s3.amazonaws.com/OtpSharp/LICENSE.txt) |
+| Owin | [https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt](https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt) |
+| Owin.Security.Providers.OpenIDBase | [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT) |
+| PagedList | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
+| PagedList.Mvc | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
+| Pipelines.Sockets.Unofficial | [https://raw.githubusercontent.com/mgravell/Pipelines.Sockets.Unofficial/master/LICENSE](https://raw.githubusercontent.com/mgravell/Pipelines.Sockets.Unofficial/master/LICENSE) |
+| Pomelo.EntityFrameworkCore.MySql | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| Pomelo.JsonObject |
+| Portable.BouncyCastle | [https://www.bouncycastle.org/csharp/licence.html](https://www.bouncycastle.org/csharp/licence.html) |
+| Proc | [https://github.com/nullean/proc/blob/master/license.txt](https://github.com/nullean/proc/blob/master/license.txt) |
+| Quartz | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Quartz.Jobs | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Quartz.Plugins | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Quartz.Plugins.TimeZoneConverter | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Quartz.Serialization.Json | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| RabbitMQ.Client | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| Rebex.Common | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| Rebex.Ftp | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| Rebex.Networking | [https://aka.ms/deprecateLicenseUrl](https://aka.ms/deprecateLicenseUrl) |
+| RedLock.net | [https://github.com/samcook/RedLock.net/blob/master/LICENSE](https://github.com/samcook/RedLock.net/blob/master/LICENSE) |
+| Respond | [https://github.com/scottjehl/Respond/blob/master/LICENSE-MIT](https://github.com/scottjehl/Respond/blob/master/LICENSE-MIT) |
+| RestSharp | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| Sammy.js | [https://github.com/quirkey/sammy/blob/master/LICENSE](https://github.com/quirkey/sammy/blob/master/LICENSE) |
+| SauceControl.InheritDoc | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| SharpCompress | [https://github.com/adamhathcock/sharpcompress/blob/master/LICENSE.txt](https://github.com/adamhathcock/sharpcompress/blob/master/LICENSE.txt) |
+| Spin.js |
+| SSH.NET | [https://github.com/sshnet/SSH.NET/blob/master/LICENSE](https://github.com/sshnet/SSH.NET/blob/master/LICENSE) |
+| StackExchange.Redis | [https://raw.github.com/StackExchange/StackExchange.Redis/master/LICENSE](https://raw.github.com/StackExchange/StackExchange.Redis/master/LICENSE) |
+| SweetAlert.Base | [https://github.com/t4t5/sweetalert/blob/master/LICENSE](https://github.com/t4t5/sweetalert/blob/master/LICENSE) |
+| System.Buffers | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Collections | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Collections.Immutable | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ComponentModel.Annotations | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ComponentModel.Composition | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Configuration.ConfigurationManager | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Console | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Data.DataSetExtensions | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Data.SqlClient | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Diagnostics.Debug | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Diagnostics.DiagnosticSource | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Diagnostics.PerformanceCounter | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Globalization | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.IdentityModel.Tokens.Jwt | [https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt) |
+| System.IO | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.IO.Compression | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.IO.Pipelines | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Linq | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Linq.Dynamic.Core | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| System.Linq.Expressions | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Management | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Memory | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Net.Http | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Numerics.Vectors | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Reflection | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Reflection.Emit | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Reflection.Emit.Lightweight | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Reflection.Extensions | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Reflection.TypeExtensions | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Resources.ResourceManager | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Runtime | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Runtime.Caching | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Runtime.CompilerServices.Unsafe | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Runtime.Extensions | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Runtime.InteropServices.RuntimeInformation | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Runtime.Loader | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Security.AccessControl | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Security.Cryptography.Algorithms | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Security.Cryptography.Encoding | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Security.Cryptography.Primitives | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Security.Cryptography.X509Certificates | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.Security.Permissions | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Security.Principal.Windows | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ServiceModel.Duplex | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ServiceModel.Federation | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ServiceModel.Http | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ServiceModel.NetTcp | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ServiceModel.Primitives | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.ServiceModel.Security | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Text.Encodings.Web | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Threading.Channels | [https://licenses.nuget.org/MIT](https://licenses.nuget.org/MIT) |
+| System.Threading.Tasks.Extensions | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Threading.ThreadPool | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| System.ValueTuple | [https://github.com/dotnet/corefx/blob/master/LICENSE.TXT](https://github.com/dotnet/corefx/blob/master/LICENSE.TXT) |
+| System.Xml.ReaderWriter | [http://go.microsoft.com/fwlink/?LinkId=329770](http://go.microsoft.com/fwlink/?LinkId=329770) |
+| TimeZoneConverter |
+| toastr | [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php) |
+| Twitter.Bootstrap.Less | [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT) |
+| WebActivatorEx | [http://opensource.org/licenses/Apache-2.0](http://opensource.org/licenses/Apache-2.0) |
+| WebGrease | [http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm](http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm) |
+| WireMock.Net | [https://licenses.nuget.org/Apache-2.0](https://licenses.nuget.org/Apache-2.0) |
+| YamlDotNet | [https://github.com/aaubry/YamlDotNet/blob/master/LICENSE](https://github.com/aaubry/YamlDotNet/blob/master/LICENSE) |


### PR DESCRIPTION
**N.B.**
Licence URLs can be found from the Visual Studio Package Manager Console (PMC) by running the following command:

```powershell
Get-Package | Select-Object -Unique @{name="ThirdPartyPackage"; expression={"| " + $_.Id + " | " + "[" + $_.LicenseUrl + "](" +  $_.LicenseUrl + ") |"}} | Sort-Object -Property ThirdPartyPackage
```

This command, removes duplicates, outputs the results in markdown table format (the format required for the [docs.cyclr.com](docs.cyclr.com) documentation site) and sorts the results alphabetically.  This output can then be used to update the table with the latest list of Open Source Third Party packages.