### PR TITLE
Update the CSS so the sidebar is scrollable when required.

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -981,6 +981,11 @@ span.soft {
     }
 }
 
+#mysidebar {
+    height: 90%;
+    overflow-y: auto;
+}
+
 @media (max-width: 990px) {
     #mysidebar {
         position: relative;


### PR DESCRIPTION
Certain sections (mainly Connector Guides) within the sidebar, when expanded, are too large to show all the items on the screen. The CSS has been updated so the sidebar is now scrollable when required.