### PR TITLE
Fix Liquid Syntax error(s)

### DIFF
--- a/pages/connector-authentication/eventbrite.md
+++ b/pages/connector-authentication/eventbrite.md
@@ -20,9 +20,7 @@ Create an API key and client secret on the [API keys page](https://www.eventbrit
 2. Enter a **First Name** and **Last Name** to associate with the keys.
 3. Enter an **Application URL**, this can be any URL but is required.
 4. Enter the **OAuth Redirect URI** of your Cyclr account. This has the following format:
-    ```html
-    https://{{Your Cyclr service domain e.g. app-h.cyclr.com}}/connector/callback
-    ```
+    `{% raw %}https://{{Your Cyclr service domain e.g. app-h.cyclr.com}}/connector/callback{% endraw %}`
 5. Enter an **Application Name** and **Description**, these can be anything but are required.
 6. Confirm the **I have read the terms of use and agree to their terms** checkbox.
 7. Select **Create Key**.

--- a/pages/connector-authentication/googleads.md
+++ b/pages/connector-authentication/googleads.md
@@ -22,7 +22,7 @@ To access the Google Ads API endpoints, you need to enable the Google Ads API wi
 
 You need a **client ID** and **client secret** to set up the Google Ads connector in Cyclr. You can obtain these by creating OAuth 2.0 credentials for the Google project where you enabled the Google Ads API in the previous step. Google's documentation on how to do this can be found [here](https://support.google.com/cloud/answer/6158849?hl=en). You need to set up the fields below as follows:
 
--   **Authorised redirect URIs**: Your Cyclr callback URL e.g. https://{{Your Cyclr service domain e.g. app-h.cyclr.com}}/connector/callback
+-   **Authorised redirect URIs**: Your Cyclr callback URL e.g. {% raw %}https://{{Your Cyclr service domain e.g. app-h.cyclr.com}}/connector/callback{% endraw %}
 
 Once you have created OAuth 2.0 credentials, make note of the **client ID** and **client secret** as you need both needed to set up the Google Ads connector in Cyclr.
 


### PR DESCRIPTION
When building locally the following Liquid syntax errors are displayed:
```
docs-jekyll-1  |     Liquid Warning: Liquid syntax error (line 17): Expected end_of_string but found id in "{{Your Cyclr service domain e.g. app-h.cyclr.com}}" in pages/connector-authentication/eventbrite.md
docs-jekyll-1  |     Liquid Warning: Liquid syntax error (line 18): Expected end_of_string but found id in "{{Your Cyclr service domain e.g. app-h.cyclr.com}}" in pages/connector-authentication/googleads.md
```