### PR TITLE
CPT-182 Add `statusCode` and `reasonPhrase` global variables to `after_action` event.

### DIFF
--- a/pages/v2/08-custom-connectors/04-create-a-connector/07-script.md
+++ b/pages/v2/08-custom-connectors/04-create-a-connector/07-script.md
@@ -185,6 +185,8 @@ If a Method uses Paging, this function is called after each page is retrieved.
 *   **cyclr_account_id**: The internal ID of the account the script is running in
 *   **external_account_id**: The external ID of the account the script is running in
 *   **action_data**: An object used to persist data between some event handler functions, allowing data to be passed between them.  Accessible in before_action, after_action, after_action_paging, action_condition and after_error.
+*   **statusCode**: The response status code.
+*   **reasonPhrase*: The response reason phrase.
 *   **return**: true
 
 ### after_action_paging


### PR DESCRIPTION
Update the scripting documentation to add the new global variables `statusCode` and `reasonPhrase` that have been added to the `after_action` event.