### PR TITLE
Copy account cycle page

### DIFF
--- a/pages/v2/02-cyclr-configuration/02-general-settings.md
+++ b/pages/v2/02-cyclr-configuration/02-general-settings.md
@@ -25,7 +25,7 @@ menus:
 | Enable Anonymous Accounts | Allows end users to open cycle and connector seeds links without having a Cyclr account. |
 | Enable Beta/Planned Connectors | Allows beta and planned (coming soon) connectors to be displayed in the connector list.|
 | Enable Custom Connectors | Allows end user accounts to create their own custom connectors. |
-| Enable Cycle Sharing | Allows sharing of cycles across end user accounts. |
+| Enable Cycle Sharing | Allows you to [copy a cycle](copy-account-cycle) from an account as a template that you can use for multiple end user accounts. |
 | Enable Notification Emails | To enable notification emails please message our support team.
 | Enable Notification Webhook | Makes an HTTP call when there is an issue with an account’s cycles. https://docs.cyclr.com/notifications |
 |	Notification Webhook URL | URL to use when Cyclr sends notifications for cycle issues. |

--- a/pages/v2/03-templates/06-copy-account-cycle.md
+++ b/pages/v2/03-templates/06-copy-account-cycle.md
@@ -5,7 +5,7 @@ permalink: copy-account-cycle
 tags: [templates]
 menus:
     cycle-templates:
-        title: Copy a cycle as a template
+        title: Copy cycles as templates
         identifier: copy-account-cycle
         toggleonly: menutoggleonly
         weight: 6

--- a/pages/v2/03-templates/06-copy-account-cycle.md
+++ b/pages/v2/03-templates/06-copy-account-cycle.md
@@ -13,7 +13,7 @@ menus:
 {::options parse_block_html="true" /}
 <section class="card">
 
-If you create a cycle inside one of your customer’s accounts, then it’s only accessible from that account. To edit and use that cycle in other accounts without the need to rebuild the cycle, you can copy the cycle as a template.
+If you create a cycle inside one of your customer’s accounts, then by default, you can only access the cycle in that account. To edit and use that cycle in other accounts without the need to rebuild the cycle, you can copy the cycle as a template.
 
 To copy a cycle as a template, go to your console:
 

--- a/pages/v2/03-templates/06-copy-account-cycle.md
+++ b/pages/v2/03-templates/06-copy-account-cycle.md
@@ -1,5 +1,5 @@
 ---
-title: Copy a cycle as a template
+title: Copy cycles as templates
 sidebar: cyclr_sidebar
 permalink: copy-account-cycle
 tags: [templates]

--- a/pages/v2/03-templates/06-copy-account-cycle.md
+++ b/pages/v2/03-templates/06-copy-account-cycle.md
@@ -29,7 +29,7 @@ This adds the copied cycle template to your **Template Library**, where you can 
 
 ## Related pages
 
-* For information on how templates work in Cyclr, see the [Cycle Templates](https://docs.cyclr.com/cycle-templates) section.
-* For information about how to create and configure templates, see the [Create Cycle Templates](https://docs.cyclr.com/template-builder) section.
+* For information on how templates work in Cyclr, see the [Cycle Templates](cycle-templates) section.
+* For information about how to create and configure templates, see the [Create Cycle Templates](template-builder) section.
 
 </section>

--- a/pages/v2/03-templates/06-copy-account-cycle.md
+++ b/pages/v2/03-templates/06-copy-account-cycle.md
@@ -1,0 +1,35 @@
+---
+title: Copy a cycle as a template
+sidebar: cyclr_sidebar
+permalink: copy-account-cycle
+tags: [templates]
+menus:
+    cycle-templates:
+        title: Copy a cycle as a template
+        identifier: copy-account-cycle
+        toggleonly: menutoggleonly
+        weight: 6
+---
+{::options parse_block_html="true" /}
+<section class="card">
+
+If you create a cycle inside one of your customer’s accounts, then it’s only accessible from that account. To edit and use that cycle in other accounts without the need to rebuild the cycle, you can copy the cycle as a template.
+
+To copy a cycle as a template, go to your console:
+
+1. Go to **Settings** > [**General Settings**](console-general-settings) and select the **Enable Cycle Sharing** toggle.
+2. Open the cycle in the account to see the **Share** button that the toggle adds.
+3. Select **Share** and if the window shows dropdown boxes, select the connectors you want to use from the dropdowns.
+4. Select **Create Template**.
+
+This adds the copied cycle template to your **Template Library**, where you can use and modify the cycle in the same way as a template that you manually create.
+
+</section>
+<section class="card">
+
+## Related pages
+
+* For information on how templates work in Cyclr, see the [Cycle Templates](https://docs.cyclr.com/cycle-templates) section.
+* For information about how to create and configure templates, see the [Create Cycle Templates](https://docs.cyclr.com/template-builder) section.
+
+</section>


### PR DESCRIPTION
Also made the description of the cycle sharing toggle more specific on the general settings page and added links between the two pages.